### PR TITLE
Specify type as character for chromosome column when reading in genomic ranges data

### DIFF
--- a/R/readoutputs.R
+++ b/R/readoutputs.R
@@ -3,19 +3,19 @@
 #'
 #' @param nucfile file of nucleosome positions from NucleoATAC
 #' @param out desired object type, either data.frame or GRanges
-#' @return returns object of type specified by format, either data.frame or GRanges 
-#' @seealso \code{\link{readNFRs}} 
+#' @return returns object of type specified by format, either data.frame or GRanges
+#' @seealso \code{\link{readNFRs}}
 #' @export
 readNucs<-function(nucfile, out = "GRanges"){
   out = as.character(out)
   if (grepl("nucpos.bed",nucfile)){
-    nucDF=as.data.frame(readr::read_tsv(nucfile,col_names = c('chr','start','end',"z","occ","occ_lower","occ_upper","lr","nuc_signal","raw_signal","reads","nfr","fuzz")))   
+    nucDF=as.data.frame(readr::read_tsv(nucfile,col_names = c('chr','start','end',"z","occ","occ_lower","occ_upper","lr","nuc_signal","raw_signal","reads","nfr","fuzz"), col_types=cols(chr = col_character())))
   }
   else if (grepl("nucmap_combined.bed",nucfile)){
-    nucDF=as.data.frame(readr::read_tsv(nucfile,col_names = c('chr','start','end',"occ","occ_lower","occ_upper","reads","type")))       
+    nucDF=as.data.frame(readr::read_tsv(nucfile,col_names = c('chr','start','end',"occ","occ_lower","occ_upper","reads","type"), col_types=cols(chr = col_character())))
   }
   else if (grepl("occpeaks.bed",nucfile)){
-    nucDF=as.data.frame(readr::read_tsv(nucfile,col_names = c('chr','start','end',"occ","occ_lower","occ_upper","reads")))       
+    nucDF=as.data.frame(readr::read_tsv(nucfile,col_names = c('chr','start','end',"occ","occ_lower","occ_upper","reads"), col_types=cols(chr = col_character())))       
   }
   else{
     stop("File name doesn't seem to include stantard format of NucleoATAC output")
@@ -24,31 +24,31 @@ readNucs<-function(nucfile, out = "GRanges"){
     return(nucDF)
   }
   else if (out=="GRanges"){
-    if (grepl("nucpos.bed",nucfile)){   
-      nucGR = with(nucDF,GenomicRanges::GRanges(chr,IRanges::IRanges(start,start), 
-                        z=z, 
-                        occ = occ, 
-                        occ_lower = occ_lower, 
-                        occ_upper = occ_upper, 
-                        lr = lr, 
-                        nuc_signal=nuc_signal, 
+    if (grepl("nucpos.bed",nucfile)){
+      nucGR = with(nucDF,GenomicRanges::GRanges(chr,IRanges::IRanges(start,start),
+                        z=z,
+                        occ = occ,
+                        occ_lower = occ_lower,
+                        occ_upper = occ_upper,
+                        lr = lr,
+                        nuc_signal=nuc_signal,
                         raw_signal = raw_signal,
-                        reads=reads, 
-                        nfr=nfr, 
+                        reads=reads,
+                        nfr=nfr,
                         fuzz=fuzz))
     }
     else if (grepl("nucmap_combined.bed",nucfile)){
-      nucGR = with(nucDF,GenomicRanges::GRanges(chr,IRanges::IRanges(start,start), 
-                             occ = occ, 
-                             occ_lower = occ_lower, 
-                             occ_upper = occ_upper, 
-                             type = type))      
+      nucGR = with(nucDF,GenomicRanges::GRanges(chr,IRanges::IRanges(start,start),
+                             occ = occ,
+                             occ_lower = occ_lower,
+                             occ_upper = occ_upper,
+                             type = type))
     }
     else if (grepl("occpeaks.bed",nucfile)){
-      nucGR = with(nucDF,GenomicRanges::GRanges(chr,IRanges::IRanges(start,start), 
-                                 occ = occ, 
-                                 occ_lower = occ_lower, 
-                                 occ_upper = occ_upper))      
+      nucGR = with(nucDF,GenomicRanges::GRanges(chr,IRanges::IRanges(start,start),
+                                 occ = occ,
+                                 occ_lower = occ_lower,
+                                 occ_upper = occ_upper))
     }
   }
   else{
@@ -60,8 +60,8 @@ readNucs<-function(nucfile, out = "GRanges"){
 #'
 #' @param nfrfile file of nucleosome positions from NucleoATAC
 #' @param format desired object type, either data.frame or GRanges
-#' @return returns object of type specified by format, either data.frame or GRanges 
-#' @seealso \code{\link{readNucs}} 
+#' @return returns object of type specified by format, either data.frame or GRanges
+#' @seealso \code{\link{readNucs}}
 #' @export
 readNFRs<-function(nfrfile, format = "GRanges"){
   format = as.character(format)
@@ -76,14 +76,14 @@ readNFRs<-function(nfrfile, format = "GRanges"){
   }
   else if (format=="GRanges"){
     if (ncol(nfrDF) == 7){
-      return(with(nfrDF,GenomicRanges::GRanges(chr,IRanges::IRanges(start,end-1), 
-                          occ = occ, 
+      return(with(nfrDF,GenomicRanges::GRanges(chr,IRanges::IRanges(start,end-1),
+                          occ = occ,
                           min_occ_upper = min_occ_upper,
                           ins = ins_density,
                           bias = bias_density)))
     }else if (ncol(nfrDF) == 8){
-      return(with(nfrDF,GenomicRanges::GRanges(chr,IRanges::IRanges(start,end-1), 
-                                occ = occ, 
+      return(with(nfrDF,GenomicRanges::GRanges(chr,IRanges::IRanges(start,end-1),
+                                occ = occ,
                                 min_occ_upper = min_occ_upper,
                                 ins = ins_density,
                                 bias = bias_density,
@@ -102,7 +102,7 @@ readNFRs<-function(nfrfile, format = "GRanges"){
 #' @param start start (0-based)
 #' @param end end (1-based)
 #' @param empty value for positions not in bedgraph to take (default NA)
-#' @return returns vector of bedgraph values for interval 
+#' @return returns vector of bedgraph values for interval
 #' @seealso \code{\link{readNucs}}  \code{\link{readNFRs}}
 #' @export
 readBedgraph<-function(bgfile, chrom, start, end, empty = NA){
@@ -114,4 +114,3 @@ readBedgraph<-function(bgfile, chrom, start, end, empty = NA){
   }
   return(out)
 }
-


### PR DESCRIPTION
I am working with an ATAC-seq dataset aligned to version 6 of the Drosophila genome (dm6). I was getting an error when loading the nucleosome positions because the program thought the chromosome name was a number rather than a string. In trying to resolve this error I discovered that this is because readr uses the first 100 rows to guess the data type of the columns. dm6 has a lot of unmapped contigs that are treated as chromosomes and these are identified by numbers which is causing readr to guess their type as double instead of character. I modified your code to explicitly treat the first column as a string so that it could be read into a Genomic Ranges object and that seemed to fix the problem. I only changed lines 12, 15 and 18 in readoutputs.R. I am not sure why other parts of the code are also highlighted. Thanks!